### PR TITLE
Update Connection interface to default to edge interface

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -23,7 +23,7 @@ export interface ConnectionArguments {
 }
 
 // Relay Response
-export interface Connection<T, CustomEdge extends Edge<T>> {
+export interface Connection<T, CustomEdge extends Edge<T> = Edge<T>> {
   edges: Array<CustomEdge>
   pageInfo: PageInfo
   totalCount: number


### PR DESCRIPTION
First, thanks for a great lib. It's been working well for me!

That said, I don't have a use-case for "Custom Edges" and my code is instrumented to use `Connection<T>` in many places. This change would allow me to update the latest version of this library without having to re-write all my types to be `Connection<T, Edge<T>>` (in which the first `T` is unnecessary anyway). I hope this makes sense. 