### PR TITLE
Adds support for inferring a custom edge type

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,7 @@ fields to the edge or the node, you can pass the following option:
 ```ts
 import { findManyCursorConnection } from '@devoxa/prisma-relay-cursor-connection'
 
-const result = await findManyCursorConnection<
-  Todo,
-  { id: string },
-  Todo & { extraNodeField: string },
-  { extraEdgeField: string; cursor: string; node: Todo & { extraNodeField: string } }
->(
+const result = await findManyCursorConnection(
   (args) => client.todo.findMany(args),
   () => client.todo.count(),
   { first: 5, after: 'eyJpZCI6MTZ9' },
@@ -153,6 +148,8 @@ const result = await findManyCursorConnection<
   }
 )
 ```
+
+Out-of-the box this will have the revised types inferred for you.
 
 ### Resolve information
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,11 +90,18 @@ export async function findManyCursorConnection<
   const endCursor =
     records.length > 0 ? encodeCursor(records[records.length - 1], options) : undefined
 
+  // Allow the recordToEdge function to return a custom edge type which will be inferred
+  type EdgeExtended = typeof options.recordToEdge extends (record: Record) => infer X
+    ? X extends CustomEdge
+      ? X & { cursor: string }
+      : CustomEdge
+    : CustomEdge
+
   const edges = records.map((record) => {
     return {
       ...options.recordToEdge(record),
       cursor: encodeCursor(record, options),
-    } as CustomEdge
+    } as EdgeExtended
   })
 
   return {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -529,3 +529,52 @@ describe('prisma-relay-cursor-connection', () => {
     })
   })
 })
+
+// These are not real tests which run, but rather a way to ensure that the types are correct
+// when tsc runs
+const typecheckForInferredTypes = async () => {
+  let client: PrismaClient
+    // Default will get the inferred types from prisma
+  ;(await findManyCursorConnection(
+    (args) => client.todo.findMany(args),
+    () => client.todo.count(),
+    {}
+  )) satisfies {
+    edges: { cursor: string; node: { id: string; text: string; isCompleted: boolean } }[]
+  }
+
+  // Handles edge type additions
+  ;(await findManyCursorConnection(
+    (args) => client.todo.findMany(args),
+    () => client.todo.count(),
+    {},
+    {
+      recordToEdge: (record) => ({ node: record, extraEdgeField: 'Bar' }),
+    }
+  )) satisfies {
+    edges: {
+      cursor: string
+      node: { id: string; text: string; isCompleted: boolean }
+      extraEdgeField: string
+    }[]
+  }
+
+  // Handles edge type additions
+  ;(await findManyCursorConnection(
+    (args) => client.todo.findMany(args),
+    () => client.todo.count(),
+    {},
+    {
+      recordToEdge: (record) => ({
+        node: { ...record, extraNodeField: 'a' },
+      }),
+    }
+  )) satisfies {
+    edges: {
+      cursor: string
+      node: { id: string; text: string; isCompleted: boolean; extraNodeField: string }
+    }[]
+  }
+}
+
+typecheckForInferredTypes


### PR DESCRIPTION
:wave: I was writing a custom edge and figured it was worth some time adding inference to the types for this edge rather than making some pretty long types at the end-user point

To make sure this stays working, I added some examples in the tests folder which uses the new `satisfies` operator to verify the types match a particular shape